### PR TITLE
feat: logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ By default, the script is configured to use specfic paths in system and all is d
 | ResticRepositoryPassLenght | `110`                                                                          | Restic repository default password length           |
 | ResticPasswordFile         | `/root/.restic-repo`                                                           | Restic password file used to perform backup         |
 | MariaDBClientConf          | `/root/.my-backup.cnf`                                                         | MariaDB Client config file used to perform backup   |
-| PathToBackup               | `/etc /srv /var /usr/local/bin/restic /root/.restic-repo /root/.my-backup.cnf` | Path in filesystem backuped by default              |
+| PathToBackup               | `/etc /srv /var /usr/local/bin/restic /root/.restic-repo /root/.my-backup.cnf` | Path in filesystem backuped by default. Note, filesystem default path `/var/lib/mysql`, `/var/lib/influxdb` and `/var/lib/elasticsearch` as excluded              |
 | ResticVersion              | `0.9.6`                                                                        | Restic version to use                               |
 | ResticDlURL                | `<Restic artifact on https://github.com/restic/restic>`                        | Restic download URL                                 |
 | JobLogFile                 | `/srv/rgm/backup/restic-backup_$(date +"%a").log`                              | Path for backup log file                            |

--- a/rgm-backup.sh
+++ b/rgm-backup.sh
@@ -126,7 +126,7 @@ function perform_influxdb_dump() {
 
 function upload_mysql_dump() {
     printf "####################################\n" | tee -a ${JobLogFile}
-    printf "# Upload mariadb dumps into restic target start\n" | tee -a ${JobLogFile}
+    printf "# Upload mariadb dumps into restic target start" | tee -a ${JobLogFile}
 
     ${BkpBinary} --repo ${BkpTarget} -p ${ResticPasswordFile} backup "${TempWorkDir}/mariadbdump" | tee -a ${JobLogFile}
     printf "####################################\n" | tee -a ${JobLogFile}
@@ -135,7 +135,7 @@ function upload_mysql_dump() {
 
 function upload_influx_backup() {
     printf "####################################\n" | tee -a ${JobLogFile}
-    printf "# Upload influx dumps into restic target start\n" | tee -a ${JobLogFile}
+    printf "# Upload influx dumps into restic target start" | tee -a ${JobLogFile}
 
     ${BkpBinary} --repo ${BkpTarget} -p ${ResticPasswordFile} backup "${TempWorkDir}/influxdbbackup" | tee -a ${JobLogFile}
     printf "####################################\n" | tee -a ${JobLogFile}
@@ -144,11 +144,11 @@ function upload_influx_backup() {
 
 function upload_fs_backup() {
     printf "####################################\n" | tee -a ${JobLogFile}
-    printf "# Start fs folder backup\n" | tee -a ${JobLogFile}
+    printf "# Start fs folder backup" | tee -a ${JobLogFile}
 
     for fold in ${PathToBackup}
     do
-        printf "Backup folder ${fold}\n" | tee -a ${JobLogFile}
+        printf "\nBackup folder ${fold}" | tee -a ${JobLogFile}
         ${BkpBinary} --repo ${BkpTarget} -p ${ResticPasswordFile} --exclude ${BkpTarget} --exclude /var/lib/elasticsearch --exclude /var/lib/mysql --exclude /var/lib/influxdb backup ${fold} | tee -a ${JobLogFile}
     done 
     printf "####################################\n" | tee -a ${JobLogFile}

--- a/rgm-backup.sh
+++ b/rgm-backup.sh
@@ -125,7 +125,7 @@ function upload_influx_backup() {
 function upload_fs_backup() {
     for fold in ${PathToBackup}
     do
-         ${BkpBinary} --repo ${BkpTarget} -p ${ResticPasswordFile} --exclude ${BkpTarget} backup ${fold} | tee -a ${JobLogFile}
+         ${BkpBinary} --repo ${BkpTarget} -p ${ResticPasswordFile} --exclude ${BkpTarget} --exclude /var/lib/elasticsearch --exclude /var/lib/mysql --exclude /var/lib/influxdb backup ${fold} | tee -a ${JobLogFile}
     done 
 }
 

--- a/rgm-backup.sh
+++ b/rgm-backup.sh
@@ -86,6 +86,9 @@ function init_restic_repository() {
 }
 
 function perform_mysql_dump() {
+    printf "####################################\n" | tee -a ${JobLogFile}
+    printf "# Starting mysql dumps\n" | tee -a ${JobLogFile}
+    printf "####################################\n" | tee -a ${JobLogFile}
     DumpDest="${TempWorkDir}/mariadbdump"
     mkdir ${DumpDest}
     Now="$(date +"%a")"
@@ -94,11 +97,18 @@ function perform_mysql_dump() {
     for db in $Bases
     do
         File=${DumpDest}/${db}.${Now}.sql.gz
+        printf "Dumping database ${db}\n" | tee -a ${JobLogFile}
         mysqldump --defaults-extra-file=${MariaDBClientConf} --compact --order-by-primary --add-drop-table ${db} -R 2>> ${JobLogFile} | gzip -9 > ${File}
     done
+    printf "####################################\n" | tee -a ${JobLogFile}
+    printf "# End mysql dumps\n" | tee -a ${JobLogFile}
+    printf "####################################\n" | tee -a ${JobLogFile}
 }
 
 function perform_influxdb_dump() {
+    printf "####################################\n" | tee -a ${JobLogFile}
+    printf "# Starting influxdb dumps\n" | tee -a ${JobLogFile}
+    printf "####################################\n" | tee -a ${JobLogFile}
     DumpDest="${TempWorkDir}/influxdbbackup"
     mkdir ${DumpDest}
     Now="$(date +"%a")"
@@ -106,32 +116,58 @@ function perform_influxdb_dump() {
     for db in ${Bases}
     do
         Folder=${DumpDest}/${db}.${Now}
+        printf "Dumping database ${db}\n" | tee -a ${JobLogFile}
         influxd backup -database ${db} ${Folder} | tee -a ${JobLogFile}
         tar czf ${Folder}.tar.gz ${Folder}
         rm -rf ${Folder}
     done
+    printf "####################################\n" | tee -a ${JobLogFile}
+    printf "# End influxdb dumps\n" | tee -a ${JobLogFile}
+    printf "####################################\n" | tee -a ${JobLogFile}
 }
 
 function upload_mysql_dump() {
-    printf "Upload mariadb dumps into restic target\n"
+    printf "####################################\n" | tee -a ${JobLogFile}
+    printf "# Upload mariadb dumps into restic target start\n" | tee -a ${JobLogFile}
+    printf "####################################\n" | tee -a ${JobLogFile}
     ${BkpBinary} --repo ${BkpTarget} -p ${ResticPasswordFile} backup "${TempWorkDir}/mariadbdump" | tee -a ${JobLogFile}
+    printf "####################################\n" | tee -a ${JobLogFile}
+    printf "# Upload mariadb dumps into restic target finished\n" | tee -a ${JobLogFile}
+    printf "####################################\n" | tee -a ${JobLogFile}
 }
 
 function upload_influx_backup() {
-    printf "Upload influx dumps into restic target\n"
+    printf "####################################\n" | tee -a ${JobLogFile}
+    printf "# Upload influx dumps into restic target start\n" | tee -a ${JobLogFile}
+    printf "####################################\n" | tee -a ${JobLogFile}
     ${BkpBinary} --repo ${BkpTarget} -p ${ResticPasswordFile} backup "${TempWorkDir}/influxdbbackup" | tee -a ${JobLogFile}
+    printf "####################################\n" | tee -a ${JobLogFile}
+    printf "# Upload mariadb dumps into restic target end\n" | tee -a ${JobLogFile}
+    printf "####################################\n" | tee -a ${JobLogFile}
 }
 
 function upload_fs_backup() {
+    printf "####################################\n" | tee -a ${JobLogFile}
+    printf "# Start fs folder backup\n" | tee -a ${JobLogFile}
+    printf "####################################\n" | tee -a ${JobLogFile}
     for fold in ${PathToBackup}
     do
-         ${BkpBinary} --repo ${BkpTarget} -p ${ResticPasswordFile} --exclude ${BkpTarget} --exclude /var/lib/elasticsearch --exclude /var/lib/mysql --exclude /var/lib/influxdb backup ${fold} | tee -a ${JobLogFile}
+        printf "Backup folder ${fold}\n" | tee -a ${JobLogFile}
+        ${BkpBinary} --repo ${BkpTarget} -p ${ResticPasswordFile} --exclude ${BkpTarget} --exclude /var/lib/elasticsearch --exclude /var/lib/mysql --exclude /var/lib/influxdb backup ${fold} | tee -a ${JobLogFile}
     done 
+    printf "####################################\n" | tee -a ${JobLogFile}
+    printf "# End fs folder backup\n" | tee -a ${JobLogFile} 
+    printf "####################################\n" | tee -a ${JobLogFile}
 }
 
 function clean_old_repository_files() {
-    printf "Perform repository deletion of snapshots older than ${BkpRetention}\n" | tee -a ${JobLogFile}
+    printf "####################################\n" | tee -a ${JobLogFile}
+    printf "# Start backup retention cleaning (with retention ${BkpRtention}) \n" | tee -a ${JobLogFile}
+    printf "####################################\n" | tee -a ${JobLogFile}
     ${BkpBinary} --repo ${BkpTarget} -p ${ResticPasswordFile} forget --keep-daily ${BkpRetention} --prune | tee -a ${JobLogFile}
+    printf "####################################\n" | tee -a ${JobLogFile}
+    printf "# End backup retention cleaning\n" | tee -a ${JobLogFile}
+    printf "####################################\n" | tee -a ${JobLogFile}
 }
 
 ## Main job
@@ -192,6 +228,11 @@ if [ ${opt_purge} ];then
     clean_old_repository_files
     exit 0
 else
+    printf "######################################################\n" | tee ${JobLogFile}
+    printf "######################################################\n" | tee -a ${JobLogFile}
+    printf "# Startup RGM backup procedure\n" – tee -a ${JobLogFile}
+    printf "######################################################\n" | tee -a ${JobLogFile}
+    printf "######################################################\n" | tee -a ${JobLogFile}
     setup_environment
     cd ${TempWorkDir}
     perform_mysql_dump
@@ -201,5 +242,10 @@ else
     upload_fs_backup
     clean_env
     clean_old_repository_files
+    printf "######################################################\n" | tee ${JobLogFile}
+    printf "######################################################\n" | tee -a ${JobLogFile}
+    printf "# End of RGM backup procedure\n" – tee -a ${JobLogFile}
+    printf "######################################################\n" | tee -a ${JobLogFile}
+    printf "######################################################\n" | tee -a ${JobLogFile}
 fi
 # vim: expandtab sw=4 ts=4:

--- a/rgm-backup.sh
+++ b/rgm-backup.sh
@@ -87,8 +87,8 @@ function init_restic_repository() {
 
 function perform_mysql_dump() {
     printf "####################################\n" | tee -a ${JobLogFile}
-    printf "# Starting mysql dumps\n" | tee -a ${JobLogFile}
-    printf "####################################\n" | tee -a ${JobLogFile}
+    printf "# Starting mysql dumps\n\n" | tee -a ${JobLogFile}
+    
     DumpDest="${TempWorkDir}/mariadbdump"
     mkdir ${DumpDest}
     Now="$(date +"%a")"
@@ -101,14 +101,13 @@ function perform_mysql_dump() {
         mysqldump --defaults-extra-file=${MariaDBClientConf} --compact --order-by-primary --add-drop-table ${db} -R 2>> ${JobLogFile} | gzip -9 > ${File}
     done
     printf "####################################\n" | tee -a ${JobLogFile}
-    printf "# End mysql dumps\n" | tee -a ${JobLogFile}
-    printf "####################################\n" | tee -a ${JobLogFile}
+    printf "# End mysql dumps\n\n" | tee -a ${JobLogFile}
 }
 
 function perform_influxdb_dump() {
     printf "####################################\n" | tee -a ${JobLogFile}
-    printf "# Starting influxdb dumps\n" | tee -a ${JobLogFile}
-    printf "####################################\n" | tee -a ${JobLogFile}
+    printf "# Starting influxdb dumps\n\n" | tee -a ${JobLogFile}
+
     DumpDest="${TempWorkDir}/influxdbbackup"
     mkdir ${DumpDest}
     Now="$(date +"%a")"
@@ -122,52 +121,48 @@ function perform_influxdb_dump() {
         rm -rf ${Folder}
     done
     printf "####################################\n" | tee -a ${JobLogFile}
-    printf "# End influxdb dumps\n" | tee -a ${JobLogFile}
-    printf "####################################\n" | tee -a ${JobLogFile}
+    printf "# End influxdb dumps\n\n" | tee -a ${JobLogFile}
 }
 
 function upload_mysql_dump() {
     printf "####################################\n" | tee -a ${JobLogFile}
-    printf "# Upload mariadb dumps into restic target start\n" | tee -a ${JobLogFile}
-    printf "####################################\n" | tee -a ${JobLogFile}
+    printf "# Upload mariadb dumps into restic target start\n\n" | tee -a ${JobLogFile}
+
     ${BkpBinary} --repo ${BkpTarget} -p ${ResticPasswordFile} backup "${TempWorkDir}/mariadbdump" | tee -a ${JobLogFile}
     printf "####################################\n" | tee -a ${JobLogFile}
-    printf "# Upload mariadb dumps into restic target finished\n" | tee -a ${JobLogFile}
-    printf "####################################\n" | tee -a ${JobLogFile}
+    printf "# Upload mariadb dumps into restic target finished\n\n" | tee -a ${JobLogFile}
 }
 
 function upload_influx_backup() {
     printf "####################################\n" | tee -a ${JobLogFile}
-    printf "# Upload influx dumps into restic target start\n" | tee -a ${JobLogFile}
-    printf "####################################\n" | tee -a ${JobLogFile}
+    printf "# Upload influx dumps into restic target start\n\n" | tee -a ${JobLogFile}
+
     ${BkpBinary} --repo ${BkpTarget} -p ${ResticPasswordFile} backup "${TempWorkDir}/influxdbbackup" | tee -a ${JobLogFile}
     printf "####################################\n" | tee -a ${JobLogFile}
-    printf "# Upload mariadb dumps into restic target end\n" | tee -a ${JobLogFile}
-    printf "####################################\n" | tee -a ${JobLogFile}
+    printf "# Upload mariadb dumps into restic target end\n\n" | tee -a ${JobLogFile}
 }
 
 function upload_fs_backup() {
     printf "####################################\n" | tee -a ${JobLogFile}
-    printf "# Start fs folder backup\n" | tee -a ${JobLogFile}
-    printf "####################################\n" | tee -a ${JobLogFile}
+    printf "# Start fs folder backup\n\n" | tee -a ${JobLogFile}
+
     for fold in ${PathToBackup}
     do
         printf "Backup folder ${fold}\n" | tee -a ${JobLogFile}
         ${BkpBinary} --repo ${BkpTarget} -p ${ResticPasswordFile} --exclude ${BkpTarget} --exclude /var/lib/elasticsearch --exclude /var/lib/mysql --exclude /var/lib/influxdb backup ${fold} | tee -a ${JobLogFile}
     done 
     printf "####################################\n" | tee -a ${JobLogFile}
-    printf "# End fs folder backup\n" | tee -a ${JobLogFile} 
-    printf "####################################\n" | tee -a ${JobLogFile}
+    printf "# End fs folder backup\n\n" | tee -a ${JobLogFile} 
 }
 
 function clean_old_repository_files() {
     printf "####################################\n" | tee -a ${JobLogFile}
-    printf "# Start backup retention cleaning (with retention ${BkpRtention}) \n" | tee -a ${JobLogFile}
-    printf "####################################\n" | tee -a ${JobLogFile}
+    printf "# Start backup retention cleaning (with retention ${BkpRtention}) \n\n" | tee -a ${JobLogFile}
+
     ${BkpBinary} --repo ${BkpTarget} -p ${ResticPasswordFile} forget --keep-daily ${BkpRetention} --prune | tee -a ${JobLogFile}
     printf "####################################\n" | tee -a ${JobLogFile}
-    printf "# End backup retention cleaning\n" | tee -a ${JobLogFile}
-    printf "####################################\n" | tee -a ${JobLogFile}
+    printf "# End backup retention cleaning\n\n" | tee -a ${JobLogFile}
+
 }
 
 ## Main job
@@ -232,7 +227,7 @@ else
     printf "######################################################\n" | tee -a ${JobLogFile}
     printf "# Startup RGM backup procedure\n" – tee -a ${JobLogFile}
     printf "######################################################\n" | tee -a ${JobLogFile}
-    printf "######################################################\n" | tee -a ${JobLogFile}
+    printf "######################################################\n\n" | tee -a ${JobLogFile}
     setup_environment
     cd ${TempWorkDir}
     perform_mysql_dump

--- a/rgm-backup.sh
+++ b/rgm-backup.sh
@@ -117,7 +117,7 @@ function perform_influxdb_dump() {
     do
         Folder=${DumpDest}/${db}.${Now}
         printf "Dumping database ${db}\n" | tee -a ${JobLogFile}
-        influxd backup -database ${db} ${Folder} | tee -a ${JobLogFile}
+        influxd backup -database ${db} ${Folder} 1> ${JobLogFile} 2>/dev/null
         tar czf ${Folder}.tar.gz ${Folder}
         rm -rf ${Folder}
     done

--- a/rgm-backup.sh
+++ b/rgm-backup.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 #
-Version=1.0
+Version=1.0.1
 Name=rgm-backup.sh
 # RGM platform backup script using restic solution
 #
@@ -116,7 +116,7 @@ function perform_influxdb_dump() {
     do
         Folder=${DumpDest}/${db}.${Now}
         printf "Dumping database ${db}\n" | tee -a ${JobLogFile}
-        influxd backup -database ${db} ${Folder} 1> ${JobLogFile} 2>/dev/null
+        influxd backup -database ${db} ${Folder} 1>> ${JobLogFile} 2>/dev/null
         tar czf ${Folder}.tar.gz ${Folder}
         rm -rf ${Folder}
     done
@@ -225,7 +225,7 @@ if [ ${opt_purge} ];then
 else
     printf "######################################################\n" | tee ${JobLogFile}
     printf "######################################################\n" | tee -a ${JobLogFile}
-    printf "# Startup RGM backup procedure\n" – tee -a ${JobLogFile}
+    printf "# Startup RGM backup procedure\n" | tee -a ${JobLogFile}
     printf "######################################################\n" | tee -a ${JobLogFile}
     printf "######################################################\n\n" | tee -a ${JobLogFile}
     setup_environment
@@ -237,9 +237,9 @@ else
     upload_fs_backup
     clean_env
     clean_old_repository_files
-    printf "######################################################\n" | tee ${JobLogFile}
     printf "######################################################\n" | tee -a ${JobLogFile}
-    printf "# End of RGM backup procedure\n" – tee -a ${JobLogFile}
+    printf "######################################################\n" | tee -a ${JobLogFile}
+    printf "# End of RGM backup procedure\n" | tee -a ${JobLogFile}
     printf "######################################################\n" | tee -a ${JobLogFile}
     printf "######################################################\n" | tee -a ${JobLogFile}
 fi

--- a/rgm-backup.sh
+++ b/rgm-backup.sh
@@ -87,7 +87,7 @@ function init_restic_repository() {
 
 function perform_mysql_dump() {
     printf "####################################\n" | tee -a ${JobLogFile}
-    printf "# Starting mysql dumps\n\n" | tee -a ${JobLogFile}
+    printf "# Starting mysql dumps\n" | tee -a ${JobLogFile}
     
     DumpDest="${TempWorkDir}/mariadbdump"
     mkdir ${DumpDest}
@@ -106,7 +106,7 @@ function perform_mysql_dump() {
 
 function perform_influxdb_dump() {
     printf "####################################\n" | tee -a ${JobLogFile}
-    printf "# Starting influxdb dumps\n\n" | tee -a ${JobLogFile}
+    printf "# Starting influxdb dumps\n" | tee -a ${JobLogFile}
 
     DumpDest="${TempWorkDir}/influxdbbackup"
     mkdir ${DumpDest}
@@ -126,7 +126,7 @@ function perform_influxdb_dump() {
 
 function upload_mysql_dump() {
     printf "####################################\n" | tee -a ${JobLogFile}
-    printf "# Upload mariadb dumps into restic target start\n\n" | tee -a ${JobLogFile}
+    printf "# Upload mariadb dumps into restic target start\n" | tee -a ${JobLogFile}
 
     ${BkpBinary} --repo ${BkpTarget} -p ${ResticPasswordFile} backup "${TempWorkDir}/mariadbdump" | tee -a ${JobLogFile}
     printf "####################################\n" | tee -a ${JobLogFile}
@@ -135,7 +135,7 @@ function upload_mysql_dump() {
 
 function upload_influx_backup() {
     printf "####################################\n" | tee -a ${JobLogFile}
-    printf "# Upload influx dumps into restic target start\n\n" | tee -a ${JobLogFile}
+    printf "# Upload influx dumps into restic target start\n" | tee -a ${JobLogFile}
 
     ${BkpBinary} --repo ${BkpTarget} -p ${ResticPasswordFile} backup "${TempWorkDir}/influxdbbackup" | tee -a ${JobLogFile}
     printf "####################################\n" | tee -a ${JobLogFile}
@@ -144,7 +144,7 @@ function upload_influx_backup() {
 
 function upload_fs_backup() {
     printf "####################################\n" | tee -a ${JobLogFile}
-    printf "# Start fs folder backup\n\n" | tee -a ${JobLogFile}
+    printf "# Start fs folder backup\n" | tee -a ${JobLogFile}
 
     for fold in ${PathToBackup}
     do
@@ -157,7 +157,7 @@ function upload_fs_backup() {
 
 function clean_old_repository_files() {
     printf "####################################\n" | tee -a ${JobLogFile}
-    printf "# Start backup retention cleaning (with retention ${BkpRtention}) \n\n" | tee -a ${JobLogFile}
+    printf "# Start backup retention cleaning (with retention ${BkpRtention}) \n" | tee -a ${JobLogFile}
 
     ${BkpBinary} --repo ${BkpTarget} -p ${ResticPasswordFile} forget --keep-daily ${BkpRetention} --prune | tee -a ${JobLogFile}
     printf "####################################\n" | tee -a ${JobLogFile}


### PR DESCRIPTION
# Feature

- Improve logging

# Fix

- Exclude mysql folder
- Exclude influxdb folder
- Exclude elasticsearch folder

## Informations

Folder exclusion was done because MySQL and InfluxDB was backup consistenly with specdific tools.  
Elasticsearch don’t need backup because is just an input datalake, and data history aren’t production relevant.